### PR TITLE
[11기 small-j] 스텝1 에스프레소 메뉴 관리

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,6 @@
+import App from './pages/app.js';
+new App(
+    document.querySelector('main'), 
+    document.querySelector('.menu-count'),
+    document.getElementById('espresso-menu-list')
+    );

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -31,10 +31,13 @@ export default class App {
     }
 
     onMenuClick = (action) => {
-        if(typeof(action.result) === 'string') {
-            this._items[action.menuId] = action.result;
+        const result = (action.isEditButton) ? 
+            prompt('메뉴명을 수정하세요', this._items[action.menuId]) : 
+            confirm('정말 삭제하시겠습니까?');
+        if(typeof(result) === 'string') {
+            this._items[action.menuId] = result;
         }
-        else if(action.result){
+        else if(result){
             this._items.splice(action.menuId, 1);
         }
         this.render();

--- a/src/js/pages/app.js
+++ b/src/js/pages/app.js
@@ -1,0 +1,42 @@
+import MenuItem from './menuItem.js';
+import MenuCount from './menuCount.js';
+
+export default class App {
+    constructor(_app, _count, _list) {
+        this._app = _app;
+        this._count = _count;
+        this._list = _list;
+        this._items = [];
+        this.init();
+        this.setEvent();
+    }
+
+    init() {
+        this.menuItem = new MenuItem(this._list, this.onMenuClick);
+        this.menuCount = new MenuCount(this._count);
+    }
+
+    render() {
+        this.menuItem.render(this._items);
+        this.menuCount.render(this._items);
+    }
+
+    setEvent() {
+        this._app.addEventListener('click', (e) => {
+            const newMenu = e.target.previousElementSibling;
+            if(newMenu.value !== undefined && newMenu.value !== '') this._items.push(newMenu.value);
+            newMenu.value = '';
+            this.render();
+        });
+    }
+
+    onMenuClick = (action) => {
+        if(typeof(action.result) === 'string') {
+            this._items[action.menuId] = action.result;
+        }
+        else if(action.result){
+            this._items.splice(action.menuId, 1);
+        }
+        this.render();
+    }
+}

--- a/src/js/pages/menuCount.js
+++ b/src/js/pages/menuCount.js
@@ -1,0 +1,10 @@
+
+export default class MenuCount {
+    constructor(_app) {
+        this._app = _app;
+    }
+
+    render(_item) {
+        this._app.innerText = `총 ${_item.length} 개`;
+    }
+}

--- a/src/js/pages/menuItem.js
+++ b/src/js/pages/menuItem.js
@@ -33,10 +33,8 @@ export default class MenuItem {
         this._app.addEventListener('click', (e) => {
             const isEditButton = e.target.classList.contains('menu-edit-button');
             const menuId = e.target.closest('li').dataset.menuId;
-            const result = (isEditButton) ? 
-            prompt('메뉴명을 수정하세요', e.target.closest('li.menu-name')) : 
-            confirm('정말 삭제하시겠습니까?');
-            this._onMenuClick({result: result, menuId: menuId});
+            
+            this._onMenuClick({isEditButton: isEditButton, menuId: menuId});
         })
     }
 }

--- a/src/js/pages/menuItem.js
+++ b/src/js/pages/menuItem.js
@@ -1,0 +1,42 @@
+export default class MenuItem {
+    constructor(_app, _onMenuClick) {
+        this._app = _app;
+        this._onMenuClick = _onMenuClick;
+        this.setEvent();
+    }
+
+    render(_items) {
+        const result = _items.map((name, index) => {
+            return `
+            <li class="menu-list-item d-flex items-center py-2" data-menu-id="${index}">
+                <span class="w-100 pl-2 menu-name">${name}</span>
+                <button
+                    type="button"
+                    class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
+                >
+                    수정
+                </button>
+                <button
+                    type="button"
+                    class="bg-gray-50 text-gray-500 text-sm menu-remove-button"
+                >
+                    삭제
+                </button>
+            </li>
+            `
+        }).join('');
+
+        this._app.innerHTML = result;
+    }
+
+    setEvent() {
+        this._app.addEventListener('click', (e) => {
+            const isEditButton = e.target.classList.contains('menu-edit-button');
+            const menuId = e.target.closest('li').dataset.menuId;
+            const result = (isEditButton) ? 
+            prompt('메뉴명을 수정하세요', e.target.closest('li.menu-name')) : 
+            confirm('정말 삭제하시겠습니까?');
+            this._onMenuClick({result: result, menuId: menuId});
+        })
+    }
+}


### PR DESCRIPTION
## 요구사항 수행
- [x]  에스프레소 메뉴에 새로운 메뉴를 확인 버튼 또는 엔터키 입력으로 추가한다.
- [x] 메뉴가 추가되고 나면, input은 빈 값으로 초기화한다.
- [x]  사용자 입력값이 빈 값이라면 추가되지 않는다.
- [x] 메뉴의 수정 버튼을 눌러 메뉴 이름 수정할 수 있다.
- [x] 메뉴 수정시 브라우저에서 제공하는 prompt 인터페이스를 활용한다.
- [x] 메뉴 삭제 버튼을 이용하여 메뉴 삭제할 수 있다.
- [x] 메뉴 삭제시 브라우저에서 제공하는 confirm 인터페이스를 활용한다.
- [x] 총 메뉴 갯수를 count하여 상단에 보여준다.


## 고민 중인 부분
- 일단 지금은 document 객체에서 3개의 요소를 받아와 로직을 처리하는 app.js로 넘겨주고 있는데 이를 하나의 요소만 받아와 다른 요소에 효과적으로 접근하는 방법.
- 컴포넌트를 메뉴리스트와 메뉴리스트 count 하는 부분으로 나눠놓았는데 이렇게 나눈 형태가 적절한지.
- 각 컴포넌트에서 의존성을 가지지 않고 독립적으로 돌아가는 것이 맞는지.