### PR TITLE
[12기 창오] 스텝2 상태 관리로 메뉴 관리하기

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
                       autocomplete="off"
               />
               <button
-                      type="button"
+                      type="submit"
                       name="submit"
                       id="espresso-menu-submit-button"
                       class="input-submit bg-green-600 ml-2"

--- a/index.html
+++ b/index.html
@@ -55,30 +55,30 @@
             <h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
             <span class="mr-2 mt-4 menu-count">총 0개</span>
           </div>
-          <form id="espresso-menu-form">
+          <form id="menu-form">
             <div class="d-flex w-100">
-              <label for="espresso-menu-name" class="input-label" hidden>
-                에스프레소 메뉴 이름
+              <label for="menu-name" class="input-label" hidden>
+                메뉴 이름
               </label>
               <input
                       type="text"
-                      id="espresso-menu-name"
-                      name="espressoMenuName"
+                      id="menu-name"
+                      name="menuName"
                       class="input-field"
-                      placeholder="에스프레소 메뉴 이름"
+                      placeholder="메뉴 이름"
                       autocomplete="off"
               />
               <button
                       type="submit"
                       name="submit"
-                      id="espresso-menu-submit-button"
+                      id="menu-submit-button"
                       class="input-submit bg-green-600 ml-2"
               >
                 확인
               </button>
             </div>
           </form>
-          <ul id="espresso-menu-list" class="mt-3 pl-0"></ul>
+          <ul id="menu-list" class="mt-3 pl-0"></ul>
         </div>
       </main>
     </div>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,49 +1,53 @@
 import * as storageAPI from "./storage.js";
 
 const $nav = document.querySelector("header > nav");
-const $menuForm = document.querySelector("#espresso-menu-form");
-const $nameInput = document.querySelector("#espresso-menu-name");
-const $menuList = document.querySelector("#espresso-menu-list");
+const $menuForm = document.querySelector("#menu-form");
+const $nameInput = document.querySelector("#menu-name");
+const $menuList = document.querySelector("#menu-list");
 const $menuCount = document.querySelector(".menu-count");
+const $menuHeading = document.querySelector(".heading > h2");
 
 const CATEGORIES = ["espresso", "frappuccino", "blended", "teavana", "desert"];
 let selectedCategory = "";
 
 const moonBucksApp = () => {
   selectedCategory = "espresso";
+  replaceMenuHeader(selectedCategory);
   initializeMenuElements(selectedCategory);
   updateMenuCount();
 
-  // 카테고리 선택 이벤트
-  $nav.addEventListener("click", (e) => {
-    e.stopPropagation();
-
-    const $target = e.target;
-    if (!$target.classList.contains("cafe-category-name")) return;
-
-    const newCategoryName = $target.dataset.categoryName;
-    if (!CATEGORIES.includes(newCategoryName)) return;
-
-    selectedCategory = newCategoryName;
-    initializeMenuElements(selectedCategory);
-    updateMenuCount();
-  });
-
-  // 메뉴 제출 이벤트
-  $menuForm.addEventListener("submit", (e) => {
-    e.preventDefault();
-
-    const newMenuName = $nameInput.value;
-    if (!isValidMenuName(newMenuName)) return;
-
-    storageAPI.createMenu(selectedCategory, newMenuName);
-    appendMenuElement(newMenuName);
-
-    updateMenuCount();
-    resetNameInput();
-  });
+  $nav.addEventListener("click", handleNavigation);
+  $menuForm.addEventListener("submit", handleSubmit);
 };
 moonBucksApp();
+
+function handleNavigation(e) {
+  e.stopPropagation();
+
+  const $target = e.target;
+  if (!$target.classList.contains("cafe-category-name")) return;
+
+  const newCategoryName = $target.dataset.categoryName;
+  if (!CATEGORIES.includes(newCategoryName)) return;
+
+  selectedCategory = newCategoryName;
+  replaceMenuHeader(selectedCategory);
+  initializeMenuElements(selectedCategory);
+  updateMenuCount();
+}
+
+function handleSubmit(e) {
+  e.preventDefault();
+
+  const newMenuName = $nameInput.value;
+  if (!isValidMenuName(newMenuName)) return;
+
+  storageAPI.createMenu(selectedCategory, newMenuName);
+  appendMenuElement(newMenuName);
+
+  updateMenuCount();
+  resetNameInput();
+}
 
 /**
  * 전달받은 메뉴 이름의 유효성을 검사한다.
@@ -207,4 +211,22 @@ function initializeMenuElements(categoryName) {
     const menu = categoryMenus[i];
     appendMenuElement(menu.name, menu.soldOut);
   }
+}
+
+/**
+ * 메뉴판 헤더 텍스트를 전달 받은 메뉴 이름으로 교체한다.
+ * @param {string} categoryName 
+ */
+function replaceMenuHeader(categoryName) {
+  if (!CATEGORIES.includes(categoryName)) return;
+
+  const heading = {
+    espresso: "☕ 에스프레소",
+    frappuccino: "🥤 프라푸치노",
+    blended: "🍹 블렌디드",
+    teavana: "🫖 티바나",
+    desert: "🍰 디저트",
+  };
+
+  $menuHeading.textContent = `${heading[categoryName]} 메뉴 관리`;
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,9 +1,15 @@
+// 요구사항
+// 1. localStorage를 활용하여 새로고침해도 데이터가 남아있다.
+// 2. 각각의 메뉴 종류별로 메뉴판을 따로 관리한다.
+//    2-1) 앱 최초 접근 시 에스프레소 메뉴가 보인다.
+// 3. 
+
 const elMenuForm = document.querySelector("#espresso-menu-form");
 const elNameInput = document.querySelector("#espresso-menu-name");
 const elMenuList = document.querySelector("#espresso-menu-list");
 const elMenuCount = document.querySelector(".menu-count");
 
-const moonBucks = () => {
+const moonBucksApp = () => {
   elMenuForm.addEventListener("submit", (e) => {
     e.preventDefault();
 
@@ -13,15 +19,15 @@ const moonBucks = () => {
 
     // 2. 메뉴 생성 및 이벤트 등록
     const elMenuItem = createMenuItemElement(newMenuName);
-    addEditButtonEvent(elMenuItem);
-    addRemoveButtonEvent(elMenuItem);
+    addEventToEditButton(elMenuItem);
+    addEventToDeleteButton(elMenuItem);
 
     // 3. 메뉴 추가 및 인풋 초기화
     addMenu(elMenuItem);
     resetNameInput();
   });
 };
-moonBucks();
+moonBucksApp();
 
 /**
  * 전달받은 메뉴 이름의 유효성을 검사한다.
@@ -69,7 +75,7 @@ const createMenuItemElement = (menuName) => {
  * 전달 받은 메뉴 아이템 엘리먼트에 "삭제" 버튼 이벤트를 추가한다.
  * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
  */
-const addRemoveButtonEvent = (elMenuItem) => {
+const addEventToDeleteButton = (elMenuItem) => {
   const elRemoveButton = elMenuItem.querySelector(".menu-remove-button");
 
   elRemoveButton.addEventListener("click", (e) => {
@@ -84,7 +90,7 @@ const addRemoveButtonEvent = (elMenuItem) => {
  * 전달 받은 메뉴 아이템 엘리먼트에 "수정" 버튼 이벤트를 추가한다.
  * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
  */
-const addEditButtonEvent = (elMenuItem) => {
+const addEventToEditButton = (elMenuItem) => {
   const elEditButton = elMenuItem.querySelector(".menu-edit-button");
 
   elEditButton.addEventListener("click", (e) => {
@@ -94,7 +100,7 @@ const addEditButtonEvent = (elMenuItem) => {
       elCurrentName.textContent
     );
 
-    if (!isValidMenuName(editedName)) return;
+    // if (!isValidMenuName(editedName)) return;
     elCurrentName.textContent = editedName;
   });
 }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,51 +1,38 @@
-const menuFormElement = document.querySelector("#espresso-menu-form");
-const nameInputElement = menuFormElement.querySelector("#espresso-menu-name");
-const menuListElement = document.querySelector("#espresso-menu-list");
-const menuCountElement = document.querySelector(".menu-count");
+const elMenuForm = document.querySelector("#espresso-menu-form");
+const elNameInput = document.querySelector("#espresso-menu-name");
+const elMenuList = document.querySelector("#espresso-menu-list");
+const elMenuCount = document.querySelector(".menu-count");
 
-menuFormElement.addEventListener("submit", (event) => {
-  event.preventDefault();
+const moonBucks = () => {
+  elMenuForm.addEventListener("submit", (e) => {
+    e.preventDefault();
 
-  // 1. 메뉴 이름 유효성 검사
-  const newMenuName = nameInputElement.value;
-  if (!isValidMenuName(newMenuName)) return;
-  
-  // 2. 메뉴 엘리먼트 생성 및 이벤트 등록
-  const menuElement = createMenuElement(newMenuName);
-  const editButton = menuElement.querySelector(".menu-edit-button");
-  const deleteButton = menuElement.querySelector(".menu-remove-button");
-  
-  editButton.addEventListener("click", (event) => {
-    const menuName = menuElement.querySelector(".menu-name");
+    // 1. 유효성 검사
+    const newMenuName = elNameInput.value;
+    if (!isValidMenuName(newMenuName)) return;
 
-    const name = prompt("메뉴명을 수정하세요.", menuName.textContent);
-    if (isValidMenuName(name)) {
-      menuName.textContent = name;
-    }
-  })
+    // 2. 메뉴 생성 및 이벤트 등록
+    const elMenuItem = createMenuItemElement(newMenuName);
+    addEditButtonEvent(elMenuItem);
+    addRemoveButtonEvent(elMenuItem);
 
-  deleteButton.addEventListener("click", (event) => {
-    if (confirm("정말 삭제하시겠습니까?")) {
-      menuElement.remove();
-      refreshMenuCount();
-    }
-  })
-
-  // 3. 메뉴 추가 및 초기화
-  menuListElement.appendChild(menuElement);
-  nameInputElement.value = "";
-  refreshMenuCount();
-});
+    // 3. 메뉴 추가 및 인풋 초기화
+    addMenu(elMenuItem);
+    resetNameInput();
+  });
+};
+moonBucks();
 
 /**
- * 메뉴 이름 유효성을 검사한다.
- * @param {string} menuName 
+ * 전달받은 메뉴 이름의 유효성을 검사한다.
+ * @param {string} menuName 메뉴 이름
  */
 const isValidMenuName = (menuName) => {
+  if (!menuName) return;
   const name = menuName.trim();
 
   if (name.length === 0) {
-    alert("값을 입력해주세요.")
+    alert("값을 입력해주세요.");
     return false;
   }
 
@@ -53,11 +40,11 @@ const isValidMenuName = (menuName) => {
 };
 
 /**
- * 메뉴 엘리먼트를 생성한다.
- * @param {string} menuName
- * @returns {HTMLLIElement} 메뉴 엘리먼트(`li`)
+ * 전달받은 메뉴 이름으로 메뉴 아이템 엘리먼트를 생성한다.
+ * @param {string} menuName 메뉴 이름
+ * @returns {HTMLLIElement} 메뉴 아이템 엘리먼트(`li`)
  */
-const createMenuElement = (menuName) => {
+const createMenuItemElement = (menuName) => {
   const template = `<li class="menu-list-item d-flex items-center py-2">
     <span class="w-100 pl-2 menu-name">${menuName}</span>
     <button
@@ -73,15 +60,66 @@ const createMenuElement = (menuName) => {
       삭제
     </button>
     </li>`;
-  const placeholder = document.createElement("div");
-  placeholder.innerHTML = template;
-  return placeholder.firstElementChild;
+  const wrapper = document.createElement("div");
+  wrapper.innerHTML = template;
+  return wrapper.firstElementChild;
 };
 
 /**
- * 메뉴 개수(`총 _개`)를 현재 아이템 개수로 갱신한다.
+ * 전달 받은 메뉴 아이템 엘리먼트에 "삭제" 버튼 이벤트를 추가한다.
+ * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
  */
-const refreshMenuCount = () => {
-  const menuItems = document.querySelectorAll(".menu-list-item");
-  menuCountElement.textContent = `총 ${menuItems.length}개`;
+const addRemoveButtonEvent = (elMenuItem) => {
+  const elRemoveButton = elMenuItem.querySelector(".menu-remove-button");
+
+  elRemoveButton.addEventListener("click", (e) => {
+    if (confirm("정말 삭제하시겠습니까?")) {
+      elMenuItem.remove();
+      updateMenuCount();
+    }
+  });
+};
+
+/**
+ * 전달 받은 메뉴 아이템 엘리먼트에 "수정" 버튼 이벤트를 추가한다.
+ * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
+ */
+const addEditButtonEvent = (elMenuItem) => {
+  const elEditButton = elMenuItem.querySelector(".menu-edit-button");
+
+  elEditButton.addEventListener("click", (e) => {
+    const elCurrentName = elMenuItem.querySelector(".menu-name");
+    const editedName = prompt(
+      "메뉴명을 수정하세요.",
+      elCurrentName.textContent
+    );
+
+    if (!isValidMenuName(editedName)) return;
+    elCurrentName.textContent = editedName;
+  });
 }
+
+/**
+ * 전달받은 메뉴 아이템 엘리먼트를 메뉴 리스트에 추가한다.
+ * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
+ */
+const addMenu = (elMenuItem) => {
+  elMenuList.appendChild(elMenuItem);
+  updateMenuCount();
+};
+
+/**
+ * 메뉴 이름 인풋값을 초기화한다.
+ */
+const resetNameInput = () => {
+  if (!elNameInput) return;
+  elNameInput.value = "";
+};
+
+/**
+ * 메뉴 카운트를 현재 메뉴 아이템 개수로 갱신한다.
+ */
+const updateMenuCount = () => {
+  const elMenuItems = elMenuList.querySelectorAll(".menu-list-item");
+  elMenuCount.textContent = `총 ${elMenuItems.length}개`;
+};

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,10 +1,10 @@
 import * as storageAPI from "./storage.js";
 
 const $nav = document.querySelector("header > nav");
-const elMenuForm = document.querySelector("#espresso-menu-form");
-const elNameInput = document.querySelector("#espresso-menu-name");
-const elMenuList = document.querySelector("#espresso-menu-list");
-const elMenuCount = document.querySelector(".menu-count");
+const $menuForm = document.querySelector("#espresso-menu-form");
+const $nameInput = document.querySelector("#espresso-menu-name");
+const $menuList = document.querySelector("#espresso-menu-list");
+const $menuCount = document.querySelector(".menu-count");
 
 const CATEGORIES = ["espresso", "frappuccino", "blended", "teavana", "desert"];
 let selectedCategory = "";
@@ -12,6 +12,7 @@ let selectedCategory = "";
 const moonBucksApp = () => {
   selectedCategory = "espresso";
   initializeMenuElements(selectedCategory);
+  updateMenuCount();
 
   // 카테고리 선택 이벤트
   $nav.addEventListener("click", (e) => {
@@ -29,10 +30,10 @@ const moonBucksApp = () => {
   });
 
   // 메뉴 제출 이벤트
-  elMenuForm.addEventListener("submit", (e) => {
+  $menuForm.addEventListener("submit", (e) => {
     e.preventDefault();
 
-    const newMenuName = elNameInput.value;
+    const newMenuName = $nameInput.value;
     if (!isValidMenuName(newMenuName)) return;
 
     storageAPI.createMenu(selectedCategory, newMenuName);
@@ -68,7 +69,9 @@ function isValidMenuName(menuName) {
  */
 function createMenuItemElement(menuName, soldOut) {
   const template = `<li class="menu-list-item d-flex items-center py-2">
-    <span class="w-100 pl-2 menu-name ${soldOut ? 'sold-out' : ''}">${menuName}</span>
+    <span class="w-100 pl-2 menu-name ${
+      soldOut ? "sold-out" : ""
+    }">${menuName}</span>
     <button
     type="button"
     class="bg-gray-50 text-gray-500 text-sm mr-1 menu-sold-out-button"
@@ -101,14 +104,14 @@ function createMenuItemElement(menuName, soldOut) {
 
 /**
  * 전달 받은 메뉴 아이템 엘리먼트에 "삭제" 버튼 이벤트를 추가한다.
- * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
+ * @param {HTMLLIElement} $menuItem 메뉴 아이템 엘리먼트(`li`)
  */
-function addEventToDeleteButton(elMenuItem) {
-  const elRemoveButton = elMenuItem.querySelector(".menu-remove-button");
+function addEventToDeleteButton($menuItem) {
+  const $removeButton = $menuItem.querySelector(".menu-remove-button");
 
-  elRemoveButton.addEventListener("click", (e) => {
+  $removeButton.addEventListener("click", (e) => {
     if (confirm("정말 삭제하시겠습니까?")) {
-      elMenuItem.remove();
+      $menuItem.remove();
       updateMenuCount();
     }
   });
@@ -116,28 +119,28 @@ function addEventToDeleteButton(elMenuItem) {
 
 /**
  * 전달 받은 메뉴 아이템 엘리먼트에 "수정" 버튼 이벤트를 추가한다.
- * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
+ * @param {HTMLLIElement} $menuItem 메뉴 아이템 엘리먼트(`li`)
  */
-function addEventToEditButton(elMenuItem) {
-  const elEditButton = elMenuItem.querySelector(".menu-edit-button");
+function addEventToEditButton($menuItem) {
+  const $editButton = $menuItem.querySelector(".menu-edit-button");
 
-  elEditButton.addEventListener("click", (e) => {
-    const elCurrentName = elMenuItem.querySelector(".menu-name");
-    const editedName = prompt(
-      "메뉴명을 수정하세요.",
-      elCurrentName.textContent
-    );
+  $editButton.addEventListener("click", (e) => {
+    const $currentName = $menuItem.querySelector(".menu-name");
+    const previousName = $currentName.textContent;
+    const editedName = prompt("메뉴명을 수정하세요.", previousName);
 
-    // if (!isValidMenuName(editedName)) return;
-    elCurrentName.textContent = editedName;
+    $currentName.textContent = editedName;
+    storageAPI.updateMenu(selectedCategory, previousName, {
+      name: editedName,
+    });
   });
 }
 
 /**
  * 전달 받은 메뉴 아이템 엘리먼트에 "품절" 버튼 이벤트를 추가한다.
- * @param {HTMLLIElement} elMenuItem 메뉴 아이템 엘리먼트(`li`)
+ * @param {HTMLLIElement} $menuItem 메뉴 아이템 엘리먼트(`li`)
  */
- function addEventToSoldOutButton($menuItem) {
+function addEventToSoldOutButton($menuItem) {
   const $soldOutButton = $menuItem.querySelector(".menu-sold-out-button");
 
   $soldOutButton.addEventListener("click", () => {
@@ -145,17 +148,13 @@ function addEventToEditButton(elMenuItem) {
     $menuName.classList.toggle("sold-out");
 
     if ($menuName.classList.contains("sold-out")) {
-      storageAPI.updateMenu(
-        selectedCategory,
-        $menuName.textContent, 
-        {
-          name: $menuName.textContent,
-          soldOut: true,
-        }
-      );
+      storageAPI.updateMenu(selectedCategory, $menuName.textContent, {
+        name: $menuName.textContent,
+        soldOut: true,
+      });
     }
-  })
- }
+  });
+}
 
 /**
  * 전달받은 메뉴 정보로 메뉴 엘리먼트를 생성하여 메뉴 리스트에 추가한다.
@@ -164,33 +163,33 @@ function addEventToEditButton(elMenuItem) {
  */
 function appendMenuElement(menuName, soldOut = false) {
   const $menuItem = createMenuItemElement(menuName, soldOut);
-  elMenuList.appendChild($menuItem);
+  $menuList.appendChild($menuItem);
 }
 
 /**
  * 메뉴 이름 인풋값을 초기화한다.
  */
 function resetNameInput() {
-  if (!elNameInput) return;
-  elNameInput.value = "";
+  if (!$nameInput) return;
+  $nameInput.value = "";
 }
 
 /**
  * 메뉴 카운트를 현재 메뉴 아이템 개수로 갱신한다.
  */
 function updateMenuCount() {
-  const elMenuItems = elMenuList.querySelectorAll(".menu-list-item");
-  elMenuCount.textContent = `총 ${elMenuItems.length}개`;
+  const $menuItems = $menuList.querySelectorAll(".menu-list-item");
+  $menuCount.textContent = `총 ${$menuItems.length}개`;
 }
 
 /**
  * 메뉴 리스트에 있는 모든 메뉴 아이템 엘리먼트를 제거한다.
  */
 function removeMenuItemElements() {
-  if (!elMenuList) return;
+  if (!$menuList) return;
 
-  while (elMenuList.firstChild) {
-    elMenuList.removeChild(elMenuList.firstChild);
+  while ($menuList.firstChild) {
+    $menuList.removeChild($menuList.firstChild);
   }
 }
 
@@ -200,7 +199,7 @@ function removeMenuItemElements() {
  */
 function initializeMenuElements(categoryName) {
   removeMenuItemElements();
-  
+
   const categoryMenus = storageAPI.loadMenuData()[categoryName];
   if (!categoryMenus) return;
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -158,7 +158,7 @@ function addEventToEditButton(elMenuItem) {
  }
 
 /**
- * 전달받은 메뉴 이름으로 메뉴 엘리먼트를 생성하여 메뉴 리스트에 추가한다.
+ * 전달받은 메뉴 정보로 메뉴 엘리먼트를 생성하여 메뉴 리스트에 추가한다.
  * @param {string} menuName - 메뉴 이름
  * @param {boolean} soldOut - 메뉴 품절 여부
  */
@@ -195,7 +195,7 @@ function removeMenuItemElements() {
 }
 
 /**
- * 전달받은 카테고리의 모든 메뉴 아이템 엘리먼트를 메뉴 리스트에 추가한다.
+ * 전달 받은 카테고리 이름에 해당하는 메뉴들을 찾아 메뉴 리스트에 추가한다.
  * @param {string} categoryName
  */
 function initializeMenuElements(categoryName) {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,15 +11,18 @@ const CATEGORIES = ["espresso", "frappuccino", "blended", "teavana", "desert"];
 let selectedCategory = "";
 
 const moonBucksApp = () => {
+  // 앱 초기화
   selectedCategory = "espresso";
   replaceMenuHeader(selectedCategory);
   initializeMenuElements(selectedCategory);
   updateMenuCount();
 
+  // 주요 이벤트 등록
   $nav.addEventListener("click", handleNavigation);
   $menuForm.addEventListener("submit", handleSubmit);
 };
 moonBucksApp();
+
 
 function handleNavigation(e) {
   e.stopPropagation();
@@ -112,9 +115,11 @@ function createMenuItemElement(menuName, soldOut) {
  */
 function addEventToDeleteButton($menuItem) {
   const $removeButton = $menuItem.querySelector(".menu-remove-button");
+  const $menuName = $menuItem.querySelector(".menu-name");
 
   $removeButton.addEventListener("click", (e) => {
     if (confirm("정말 삭제하시겠습니까?")) {
+      storageAPI.deleteMenu(selectedCategory, $menuName.textContent);
       $menuItem.remove();
       updateMenuCount();
     }
@@ -133,7 +138,7 @@ function addEventToEditButton($menuItem) {
     const previousName = $currentName.textContent;
     const editedName = prompt("메뉴명을 수정하세요.", previousName);
     if (!isValidMenuName(editedName)) return;
-    
+
     $currentName.textContent = editedName;
     storageAPI.updateMenu(selectedCategory, previousName, {
       name: editedName,
@@ -216,7 +221,7 @@ function initializeMenuElements(categoryName) {
 
 /**
  * 메뉴판 헤더 텍스트를 전달 받은 메뉴 이름으로 교체한다.
- * @param {string} categoryName 
+ * @param {string} categoryName
  */
 function replaceMenuHeader(categoryName) {
   if (!CATEGORIES.includes(categoryName)) return;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -132,7 +132,8 @@ function addEventToEditButton($menuItem) {
     const $currentName = $menuItem.querySelector(".menu-name");
     const previousName = $currentName.textContent;
     const editedName = prompt("메뉴명을 수정하세요.", previousName);
-
+    if (!isValidMenuName(editedName)) return;
+    
     $currentName.textContent = editedName;
     storageAPI.updateMenu(selectedCategory, previousName, {
       name: editedName,

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,87 @@
+const menuFormElement = document.querySelector("#espresso-menu-form");
+const nameInputElement = menuFormElement.querySelector("#espresso-menu-name");
+const menuListElement = document.querySelector("#espresso-menu-list");
+const menuCountElement = document.querySelector(".menu-count");
+
+menuFormElement.addEventListener("submit", (event) => {
+  event.preventDefault();
+
+  // 1. 메뉴 이름 유효성 검사
+  const newMenuName = nameInputElement.value;
+  if (!isValidMenuName(newMenuName)) return;
+  
+  // 2. 메뉴 엘리먼트 생성 및 이벤트 등록
+  const menuElement = createMenuElement(newMenuName);
+  const editButton = menuElement.querySelector(".menu-edit-button");
+  const deleteButton = menuElement.querySelector(".menu-remove-button");
+  
+  editButton.addEventListener("click", (event) => {
+    const menuName = menuElement.querySelector(".menu-name");
+
+    const name = prompt("메뉴명을 수정하세요.", menuName.textContent);
+    if (isValidMenuName(name)) {
+      menuName.textContent = name;
+    }
+  })
+
+  deleteButton.addEventListener("click", (event) => {
+    if (confirm("정말 삭제하시겠습니까?")) {
+      menuElement.remove();
+      refreshMenuCount();
+    }
+  })
+
+  // 3. 메뉴 추가 및 초기화
+  menuListElement.appendChild(menuElement);
+  nameInputElement.value = "";
+  refreshMenuCount();
+});
+
+/**
+ * 메뉴 이름 유효성을 검사한다.
+ * @param {string} menuName 
+ */
+const isValidMenuName = (menuName) => {
+  const name = menuName.trim();
+
+  if (name.length === 0) {
+    alert("값을 입력해주세요.")
+    return false;
+  }
+
+  return true;
+};
+
+/**
+ * 메뉴 엘리먼트를 생성한다.
+ * @param {string} menuName
+ * @returns {HTMLLIElement} 메뉴 엘리먼트(`li`)
+ */
+const createMenuElement = (menuName) => {
+  const template = `<li class="menu-list-item d-flex items-center py-2">
+    <span class="w-100 pl-2 menu-name">${menuName}</span>
+    <button
+      type="button"
+      class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
+    >
+      수정
+    </button>
+    <button
+      type="button"
+      class="bg-gray-50 text-gray-500 text-sm menu-remove-button"
+    >
+      삭제
+    </button>
+    </li>`;
+  const placeholder = document.createElement("div");
+  placeholder.innerHTML = template;
+  return placeholder.firstElementChild;
+};
+
+/**
+ * 메뉴 개수(`총 _개`)를 현재 아이템 개수로 갱신한다.
+ */
+const refreshMenuCount = () => {
+  const menuItems = document.querySelectorAll(".menu-list-item");
+  menuCountElement.textContent = `총 ${menuItems.length}개`;
+}

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,13 +1,3 @@
-// const menus = {
-//   espresso: [
-//     {
-//       name: "에스프레소 1",
-//       soldOut: true,
-//     }
-//   ],
-//   ...
-// }
-
 /**
  * 로컬 스토리지에서 카테고리별 메뉴 데이터를 가져온다.
  * @returns {object} 메뉴 목록 객체
@@ -43,7 +33,6 @@ export function createMenu(categoryName, menuName) {
  * @param {Object} newMenuData
  * @param {string} newMenuData.name
  * @param {boolean} newMenuData.soldOut
- * @returns
  */
 export function updateMenu(targetCategoryName, targetMenuName, newMenuData) {
   const menuData = loadMenuData();
@@ -55,4 +44,22 @@ export function updateMenu(targetCategoryName, targetMenuName, newMenuData) {
   if (idx === -1) return;
   selectedMenus[idx] = { ...selectedMenus[idx], ...newMenuData };
   localStorage.setItem("menus", JSON.stringify(menuData, ...selectedMenus));
+}
+
+/**
+ * 전달 받은 카테고리의 메뉴를 삭제한다.
+ * @param {string} targetCategoryName - 삭제할 메뉴의 카테고리 이름
+ * @param {string} targetMenuName - 삭제할 메뉴 이름
+ */
+export function deleteMenu(targetCategoryName, targetMenuName) {
+  const menuData = loadMenuData();
+  const selectedMenus = menuData[targetCategoryName];
+  if (!selectedMenus) return;
+
+  const newSelectedMenus = selectedMenus.filter(
+    (menu) => menu.name !== targetMenuName
+  );
+  menuData[targetCategoryName] = newSelectedMenus;
+
+  localStorage.setItem("menus", JSON.stringify(menuData));
 }

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -1,0 +1,64 @@
+// const menus = {
+//   espresso: [
+//     {
+//       name: "에스프레소 1",
+//       soldOut: true,
+//     }
+//   ],
+//   ...
+// }
+
+/**
+ * 로컬 스토리지에서 메뉴 목록을 가져온다.
+ * @returns {object} 메뉴 목록 객체
+ */
+export function loadMenuData() {
+  let existingMenus = localStorage.getItem("menus");
+  return existingMenus
+    ? JSON.parse(existingMenus)
+    : {};
+}
+
+/**
+ * 전달 받은 메뉴 이름을 카테고리 이름에 맞게 로컬 스토리지에 저장한다.
+ * @param {string} categoryName 가져올 카테고리 이름
+ * @param {string} menuName 저장할 메뉴 이름
+ */
+export function createMenu(categoryName, menuName) {
+  const menus = loadMenuData();
+  if (!menus[categoryName]) {
+    menus[categoryName] = [];
+  }
+
+  menus[categoryName].push({
+    name: menuName,
+    soldOut: false,
+  });
+
+  localStorage.setItem("menus", JSON.stringify(menus));
+}
+
+/**
+ * 
+ * @param {string} categoryName 
+ * @param {string} targetMenuName 
+ * @param {Object} newMenuData 
+ * @param {string} newMenuData.name
+ * @param {boolean} newMenuData.soldOut
+ * @returns 
+ */
+export function updateMenu(categoryName, targetMenuName, newMenuData) {
+  const menuData = loadMenuData();
+  const selectedMenus = menuData[categoryName];
+  if (!selectedMenus) return;
+
+  const idx = selectedMenus.findIndex(
+    (menu) => menu.name === targetMenuName
+  );
+
+  if (idx !== -1) {
+    selectedMenus[idx] = newMenuData;
+  }
+
+  localStorage.setItem("menus", JSON.stringify(menuData, ...selectedMenus));
+}

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -9,7 +9,7 @@
 // }
 
 /**
- * 로컬 스토리지에서 메뉴 목록을 가져온다.
+ * 로컬 스토리지에서 카테고리별 메뉴 데이터를 가져온다.
  * @returns {object} 메뉴 목록 객체
  */
 export function loadMenuData() {
@@ -39,17 +39,17 @@ export function createMenu(categoryName, menuName) {
 }
 
 /**
- * 
- * @param {string} categoryName 
+ * 전달 받은 카테고리/메뉴 이름으로 수정 대상 데이터를 찾아 새로운 데이터로 갱신한다.
+ * @param {string} targetCategoryName 
  * @param {string} targetMenuName 
  * @param {Object} newMenuData 
  * @param {string} newMenuData.name
  * @param {boolean} newMenuData.soldOut
  * @returns 
  */
-export function updateMenu(categoryName, targetMenuName, newMenuData) {
+export function updateMenu(targetCategoryName, targetMenuName, newMenuData) {
   const menuData = loadMenuData();
-  const selectedMenus = menuData[categoryName];
+  const selectedMenus = menuData[targetCategoryName];
   if (!selectedMenus) return;
 
   const idx = selectedMenus.findIndex(

--- a/src/js/storage.js
+++ b/src/js/storage.js
@@ -14,9 +14,7 @@
  */
 export function loadMenuData() {
   let existingMenus = localStorage.getItem("menus");
-  return existingMenus
-    ? JSON.parse(existingMenus)
-    : {};
+  return existingMenus ? JSON.parse(existingMenus) : {};
 }
 
 /**
@@ -40,25 +38,21 @@ export function createMenu(categoryName, menuName) {
 
 /**
  * 전달 받은 카테고리/메뉴 이름으로 수정 대상 데이터를 찾아 새로운 데이터로 갱신한다.
- * @param {string} targetCategoryName 
- * @param {string} targetMenuName 
- * @param {Object} newMenuData 
+ * @param {string} targetCategoryName
+ * @param {string} targetMenuName
+ * @param {Object} newMenuData
  * @param {string} newMenuData.name
  * @param {boolean} newMenuData.soldOut
- * @returns 
+ * @returns
  */
 export function updateMenu(targetCategoryName, targetMenuName, newMenuData) {
   const menuData = loadMenuData();
   const selectedMenus = menuData[targetCategoryName];
   if (!selectedMenus) return;
 
-  const idx = selectedMenus.findIndex(
-    (menu) => menu.name === targetMenuName
-  );
+  const idx = selectedMenus.findIndex((menu) => menu.name === targetMenuName);
 
-  if (idx !== -1) {
-    selectedMenus[idx] = newMenuData;
-  }
-
+  if (idx === -1) return;
+  selectedMenus[idx] = { ...selectedMenus[idx], ...newMenuData };
   localStorage.setItem("menus", JSON.stringify(menuData, ...selectedMenus));
 }


### PR DESCRIPTION
미리 하지않은 제 자신을 반성하며 PR 올립니다... 🤭

바닐라JS로 상태관리를 어떻게 해야할지 감이 잘 안잡혀서 어려웠습니다.

많이 부족하지만 이번에도 잘 부탁드립니다. 항상 감사합니다.

---

**코드리뷰 중점 부분**

- `함수/변수명 가독성`: 지난 스텝에서 `addRemoveButton~`과 같이 불명확한 네이밍이 있었는데, 이번에도 부탁드리겠습니다.

- `함수 구조`: 현재 로컬스토리지 모듈만 분리되어 있고, 나머지 함수들은 밑에 쭈욱 나열되어 있는데 어떻게 분리하면 좋을 지 고민입니다.

---

🎯 step2 요구사항 - 상태 관리로 메뉴 관리하기

- [x] localStorage에 데이터를 저장하여 새로고침해도 데이터가 남아있게 한다.
- [x] 에스프레소, 프라푸치노, 블렌디드, 티바나, 디저트 각각의 종류별로 메뉴판을 관리할 수 있게 만든다.
- [x] 페이지에 최초로 접근할 때는 에스프레소 메뉴가 먼저 보이게 한다.
- [x] 품절 상태인 경우를 보여줄 수 있게, 품절 버튼을 추가하고 sold-out class를 추가하여 상태를 변경한다.
