### PR TITLE
[12기 Dali] 스텝2 에스프레소 메뉴 관리

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,89 +1,89 @@
 <!DOCTYPE html>
 <html lang="kr">
-<head>
-  <meta charset="UTF-8" />
-  <title>문벅스 메뉴</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="shortcut icon" href="src/images/favicon.ico" />
-  <link rel="icon" href="src/images/favicon.png" />
-  <link rel="stylesheet" href="src/css/index.css" />
-</head>
-<body>
-<div id="app" class="px-4">
-  <div class="d-flex justify-center mt-5 w-100">
-    <div class="w-100">
-      <header class="my-4">
-        <a href="/" class="text-black">
-          <h1 class="text-center font-bold">🌝 문벅스 메뉴 관리</h1>
-        </a>
-        <nav class="d-flex justify-center flex-wrap">
-          <button
-                  data-category-name="espresso"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            ☕ 에스프레소
-          </button>
-          <button
-                  data-category-name="frappuccino"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🥤 프라푸치노
-          </button>
-          <button
-                  data-category-name="blended"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🍹 블렌디드
-          </button>
-          <button
-                  data-category-name="teavana"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🫖 티바나
-          </button>
-          <button
-                  data-category-name="desert"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🍰 디저트
-          </button>
-        </nav>
-      </header>
-      <main class="mt-10 d-flex justify-center">
-        <div class="wrapper bg-white p-10">
-          <div class="heading d-flex justify-between">
-            <h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
-            <span class="mr-2 mt-4 menu-count">총 0개</span>
-          </div>
-          <form id="espresso-menu-form">
-            <div class="d-flex w-100">
-              <label for="espresso-menu-name" class="input-label" hidden>
-                에스프레소 메뉴 이름
-              </label>
-              <input
-                      type="text"
-                      id="espresso-menu-name"
-                      name="espressoMenuName"
-                      class="input-field"
-                      placeholder="에스프레소 메뉴 이름"
-                      autocomplete="off"
-              />
+  <head>
+    <meta charset="UTF-8" />
+    <title>문벅스 메뉴</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="shortcut icon" href="src/images/favicon.ico" />
+    <link rel="icon" href="src/images/favicon.png" />
+    <link rel="stylesheet" href="src/css/index.css" />
+  </head>
+  <body>
+    <div id="app" class="px-4">
+      <div class="d-flex justify-center mt-5 w-100">
+        <div class="w-100">
+          <header class="my-4">
+            <a href="/" class="text-black">
+              <h1 class="text-center font-bold">🌝 문벅스 메뉴 관리</h1>
+            </a>
+            <nav class="d-flex justify-center flex-wrap">
               <button
-                      type="button"
-                      name="submit"
-                      id="espresso-menu-submit-button"
-                      class="input-submit bg-green-600 ml-2"
+                data-category-name="espresso"
+                class="cafe-category-name btn bg-white shadow mx-1"
               >
-                확인
+                ☕ 에스프레소
               </button>
+              <button
+                data-category-name="frappuccino"
+                class="cafe-category-name btn bg-white shadow mx-1"
+              >
+                🥤 프라푸치노
+              </button>
+              <button
+                data-category-name="blended"
+                class="cafe-category-name btn bg-white shadow mx-1"
+              >
+                🍹 블렌디드
+              </button>
+              <button
+                data-category-name="teavana"
+                class="cafe-category-name btn bg-white shadow mx-1"
+              >
+                🫖 티바나
+              </button>
+              <button
+                data-category-name="desert"
+                class="cafe-category-name btn bg-white shadow mx-1"
+              >
+                🍰 디저트
+              </button>
+            </nav>
+          </header>
+          <main class="mt-10 d-flex justify-center">
+            <div class="wrapper bg-white p-10">
+              <div class="heading d-flex justify-between">
+                <h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
+                <span class="mr-2 mt-4 menu-count">총 0개</span>
+              </div>
+              <form id="espresso-menu-form">
+                <div class="d-flex w-100">
+                  <label for="espresso-menu-name" class="input-label" hidden>
+                    에스프레소 메뉴 이름
+                  </label>
+                  <input
+                    type="text"
+                    id="espresso-menu-name"
+                    name="espressoMenuName"
+                    class="input-field"
+                    placeholder="에스프레소 메뉴 이름"
+                    autocomplete="off"
+                  />
+                  <button
+                    type="button"
+                    name="submit"
+                    id="espresso-menu-submit-button"
+                    class="input-submit bg-green-600 ml-2"
+                  >
+                    확인
+                  </button>
+                </div>
+              </form>
+              <ul id="espresso-menu-list" class="mt-3 pl-0"></ul>
             </div>
-          </form>
-          <ul id="espresso-menu-list" class="mt-3 pl-0"></ul>
+          </main>
         </div>
-      </main>
+      </div>
     </div>
-  </div>
-</div>
-<script type="module" src="./src/js/index.js"></script>
-</body>
+    <script type="module" src="./src/js/index.js"></script>
+  </body>
 </html>

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -77,9 +77,20 @@ const addNewMenu = () => {
   updateTotalMenuNum();
 };
 
+// 메뉴 품절 여부 토글
+const toggleSoldOut = ($li, idx, selectedMenuList) => {
+  const $menuName = $li.firstElementChild;
+  $menuName.classList.toggle('sold-out');
+
+  // localStorage
+  selectedMenuList[idx]['soldOut'] = !selectedMenuList[idx]['soldOut'];
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
+};
+
 // 메뉴 수정
-const editMenu = target => {
-  const $menuName = target.previousElementSibling;
+const editMenu = ($li, idx, selectedMenuList) => {
+  const $menuName = $li.firstElementChild;
   const editedName = window.prompt(
     '메뉴명을 수정하세요',
     $menuName.textContent,
@@ -88,16 +99,25 @@ const editMenu = target => {
   if (editedName === null) return;
 
   $menuName.textContent = editedName;
+
+  // localStorage
+  selectedMenuList[idx]['name'] = editedName;
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
 };
 
 // 메뉴 삭제
-const deleteMenu = target => {
-  const $selectedMenu = target.parentNode;
+const deleteMenu = ($li, idx, selectedMenuList) => {
+  const $selectedMenu = $li;
   const result = window.confirm('정말 삭제하시겠습니까?');
 
   if (!result) return;
 
   $espressoMenuList.removeChild($selectedMenu);
+
+  // localStorage
+  menuObj[selectedMenu] = selectedMenuList.filter((_, index) => index !== idx);
+  localStorage.setItem('menu', JSON.stringify(menuObj));
 };
 
 // event
@@ -120,35 +140,28 @@ $espressoMenuForm.addEventListener('keyup', e => {
   addNewMenu();
 });
 
-// 품절 버튼 클릭 시, 메뉴 품절 상태 토글
+// 메뉴별 품절, 수정, 삭제 버튼 클릭 이벤트
 $espressoMenuList.addEventListener('click', e => {
   const $li = e.target.closest('li');
-  const numOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
-
-  if (!e.target.matches('.menu-sold-out-button')) return;
-
-  const $menuName = e.target.previousElementSibling;
-  $menuName.classList.toggle('sold-out');
-
+  const idxOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
   const selectedMenuList = JSON.parse(localStorage.getItem('menu'))[
     selectedMenu
   ];
-  selectedMenuList[numOfLi]['soldOut'] = !selectedMenuList[numOfLi]['soldOut'];
-  menuObj[selectedMenu] = selectedMenuList;
-  localStorage.setItem('menu', JSON.stringify(menuObj));
-});
 
-// 수정 버튼 클릭 시, 메뉴 이름 수정
-$espressoMenuList.addEventListener('click', e => {
-  if (!e.target.matches('.menu-edit-button')) return;
-
-  editMenu(e.target);
-});
-
-// 삭제 버튼 클릭 시, 메뉴 삭제
-$espressoMenuList.addEventListener('click', e => {
-  if (!e.target.matches('.menu-remove-button')) return;
-
-  deleteMenu(e.target);
-  updateTotalMenuNum();
+  // 품절 버튼 클릭 시, 메뉴 품절 상태 토글
+  if (e.target.matches('.menu-sold-out-button')) {
+    toggleSoldOut($li, idxOfLi, selectedMenuList);
+    return;
+  }
+  // 수정 버튼 클릭 시, 메뉴 이름 수정
+  if (e.target.matches('.menu-edit-button')) {
+    editMenu($li, idxOfLi, selectedMenuList);
+    return;
+  }
+  // 삭제 버튼 클릭 시, 메뉴 삭제
+  if (e.target.matches('.menu-remove-button')) {
+    deleteMenu($li, idxOfLi, selectedMenuList);
+    updateTotalMenuNum();
+    return;
+  }
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -47,6 +47,7 @@ $espressoMenuForm.addEventListener('click', e => {
     $input.value = '';
     return;
   }
+
   const menuName = $input.value;
   addNewMenu(menuName);
   $input.value = '';
@@ -71,6 +72,7 @@ $input.addEventListener('keypress', e => {
 // 수정 버튼 클릭 시, 메뉴 이름 수정
 $espressoMenuList.addEventListener('click', e => {
   if (!e.target.matches('.menu-edit-button')) return;
+
   const $menuName = e.target.previousElementSibling;
   const editedName = window.prompt(
     '메뉴명을 수정하세요',
@@ -78,7 +80,18 @@ $espressoMenuList.addEventListener('click', e => {
   );
 
   if (editedName === null) return;
+
   $menuName.textContent = editedName;
 });
 
 // 삭제 버튼 클릭 시, 메뉴 삭제
+$espressoMenuList.addEventListener('click', e => {
+  if (!e.target.matches('.menu-remove-button')) return;
+
+  const $selectedMenu = e.target.parentNode;
+  const result = window.confirm('정말 삭제하시겠습니까?');
+
+  if (!result) return;
+
+  $espressoMenuList.removeChild($selectedMenu);
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -106,3 +106,17 @@ $espressoMenuList.addEventListener('click', e => {
   deleteMenu(e.target);
   updateTotalMenuNum();
 });
+
+// Enter 키 입력 시, 메뉴 추가
+$input.addEventListener('keypress', e => {
+  if (e.key === 'Enter') {
+    if ($input.value.trim() === '') {
+      $input.value = '';
+      return;
+    }
+
+    const menuName = $input.value;
+    addNewMenu(menuName);
+    $input.value = '';
+  }
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -3,9 +3,10 @@ const $espressoMenuForm = document.getElementById('espresso-menu-form');
 const $espressoMenuList = document.getElementById('espresso-menu-list');
 const $input = document.getElementById('espresso-menu-name');
 
-// 메뉴 추가
-const addNewMenu = menuName => {
+// 메뉴 li 만들기
+const makeMenuTemplate = menuName => {
   const $li = document.createElement('li');
+
   $li.classList.add('menu-list-item', 'd-flex', 'items-center', 'py-2');
   $li.innerHTML = `
     <span class="w-100 pl-2 menu-name">${menuName}</span>
@@ -26,6 +27,19 @@ const addNewMenu = menuName => {
   $espressoMenuList.appendChild($li);
 };
 
+// 메뉴 추가
+const addNewMenu = () => {
+  if ($input.value.trim() === '') {
+    $input.value = '';
+    return;
+  }
+
+  const menuName = $input.value;
+  makeMenuTemplate(menuName);
+  $input.value = '';
+  updateTotalMenuNum();
+};
+
 // 총 메뉴갯수 count
 const updateTotalMenuNum = () => {
   const $menuCount = document.querySelector('.menu-count');
@@ -43,29 +57,13 @@ $espressoMenuForm.addEventListener('submit', e => {
 // 확인 버튼 클릭 시, 메뉴 추가
 $espressoMenuForm.addEventListener('click', e => {
   if (e.target.id !== 'espresso-menu-submit-button') return;
-  if ($input.value.trim() === '') {
-    $input.value = '';
-    return;
-  }
-
-  const menuName = $input.value;
-  addNewMenu(menuName);
-  $input.value = '';
-  updateTotalMenuNum();
+  addNewMenu();
 });
 
 // Enter 키 입력 시, 메뉴 추가
 $input.addEventListener('keypress', e => {
   if (e.key === 'Enter') {
-    if ($input.value.trim() === '') {
-      $input.value = '';
-      return;
-    }
-
-    const menuName = $input.value;
-    addNewMenu(menuName);
-    $input.value = '';
-    updateTotalMenuNum();
+    addNewMenu();
   }
 });
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -112,6 +112,13 @@ const addNewMenu = () => {
   $input.value = '';
 };
 
+// 메뉴 변경에 따른 localStorage 업데이트
+const updateLocalStorageMenu = updatedMenuList => {
+  menuObj = JSON.parse(localStorage.getItem('menu'));
+  menuObj[selectedMenu] = updatedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
+};
+
 // 메뉴 품절 여부 토글
 const toggleSoldOut = ($li, idx, selectedMenuList) => {
   const $menuName = $li.firstElementChild;
@@ -120,9 +127,7 @@ const toggleSoldOut = ($li, idx, selectedMenuList) => {
   // localStorage
   const isSoldOut = selectedMenuList[idx]['soldOut'];
   selectedMenuList[idx]['soldOut'] = isSoldOut ? false : true;
-  menuObj = JSON.parse(localStorage.getItem('menu'));
-  menuObj[selectedMenu] = selectedMenuList;
-  localStorage.setItem('menu', JSON.stringify(menuObj));
+  updateLocalStorageMenu(selectedMenuList);
 };
 
 // 메뉴 수정
@@ -139,9 +144,7 @@ const editMenu = ($li, idx, selectedMenuList) => {
 
   // localStorage
   selectedMenuList[idx]['name'] = editedName;
-  menuObj = JSON.parse(localStorage.getItem('menu'));
-  menuObj[selectedMenu] = selectedMenuList;
-  localStorage.setItem('menu', JSON.stringify(menuObj));
+  updateLocalStorageMenu(selectedMenuList);
 };
 
 // 메뉴 삭제
@@ -155,9 +158,8 @@ const deleteMenu = ($li, idx, selectedMenuList) => {
   updateTotalMenuNum();
 
   // localStorage
-  menuObj = JSON.parse(localStorage.getItem('menu'));
-  menuObj[selectedMenu] = selectedMenuList.filter((_, index) => index !== idx);
-  localStorage.setItem('menu', JSON.stringify(menuObj));
+  selectedMenuList = selectedMenuList.filter((_, index) => index !== idx);
+  updateLocalStorageMenu(selectedMenuList);
 };
 
 // event

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,11 +1,10 @@
 // elem
 const $espressoMenuForm = document.getElementById('espresso-menu-form');
+const $espressoMenuList = document.getElementById('espresso-menu-list');
 const $input = document.getElementById('espresso-menu-name');
 
 // 메뉴 추가
 const addNewMenu = menuName => {
-  const $espressoMenuList = document.getElementById('espresso-menu-list');
-
   const $li = document.createElement('li');
   $li.classList.add('menu-list-item', 'd-flex', 'items-center', 'py-2');
   $li.innerHTML = `
@@ -29,7 +28,7 @@ const addNewMenu = menuName => {
 
 // 총 메뉴갯수 count
 const getTotalMenuNum = () => {
-  const $espressoMenuList = document.getElementById('espresso-menu-list');
+  // const $espressoMenuList = document.getElementById('espresso-menu-list');
   const $menuCount = document.querySelector('.menu-count');
 
   const totalMenuNum = $espressoMenuList.children.length;
@@ -69,3 +68,18 @@ $input.addEventListener('keypress', e => {
     getTotalMenuNum();
   }
 });
+
+// 수정 버튼 클릭 시, 메뉴 이름 수정
+$espressoMenuList.addEventListener('click', e => {
+  if (!e.target.matches('.menu-edit-button')) return;
+  const $menuName = e.target.previousElementSibling;
+  const editedName = window.prompt(
+    '메뉴명을 수정하세요',
+    $menuName.textContent,
+  );
+
+  if (editedName === null) return;
+  $menuName.textContent = editedName;
+});
+
+// 삭제 버튼 클릭 시, 메뉴 삭제

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -165,17 +165,3 @@ $espressoMenuList.addEventListener('click', e => {
     return;
   }
 });
-
-// Enter 키 입력 시, 메뉴 추가
-$input.addEventListener('keypress', e => {
-  if (e.key === 'Enter') {
-    if ($input.value.trim() === '') {
-      $input.value = '';
-      return;
-    }
-
-    const menuName = $input.value;
-    addNewMenu(menuName);
-    $input.value = '';
-  }
-});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,6 +2,15 @@
 const $espressoMenuForm = document.getElementById('espresso-menu-form');
 const $espressoMenuList = document.getElementById('espresso-menu-list');
 
+let selectedMenu = 'espresso';
+let menuObj = {
+  blended: [],
+  desert: [],
+  espresso: [],
+  frappuccino: [],
+  teavana: [],
+};
+
 // 총 메뉴갯수 count
 const updateTotalMenuNum = () => {
   const $menuCount = document.querySelector('.menu-count');
@@ -19,6 +28,12 @@ const makeMenuTemplate = menuName => {
     <span class="w-100 pl-2 menu-name">${menuName}</span>
     <button
       type="button"
+      class="bg-gray-50 text-gray-500 text-sm mr-1 menu-sold-out-button"
+    >
+      품절
+    </button>
+    <button
+      type="button"
       class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
     >
       수정
@@ -34,6 +49,18 @@ const makeMenuTemplate = menuName => {
   $espressoMenuList.appendChild($li);
 };
 
+const addMenuToLocalStorage = menuName => {
+  let selectedMenuList =
+    JSON.parse(localStorage.getItem('menu'))?.[selectedMenu] ||
+    menuObj[selectedMenu];
+  selectedMenuList.push({
+    name: menuName,
+    soldOut: false,
+  });
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
+};
+
 // 메뉴 추가
 const addNewMenu = () => {
   const $input = document.getElementById('espresso-menu-name');
@@ -45,6 +72,7 @@ const addNewMenu = () => {
   }
 
   makeMenuTemplate(menuName);
+  addMenuToLocalStorage(menuName);
   $input.value = '';
   updateTotalMenuNum();
 };
@@ -90,6 +118,24 @@ $espressoMenuForm.addEventListener('keyup', e => {
   if (e.key !== 'Enter') return;
 
   addNewMenu();
+});
+
+// 품절 버튼 클릭 시, 메뉴 품절 상태 토글
+$espressoMenuList.addEventListener('click', e => {
+  const $li = e.target.closest('li');
+  const numOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
+
+  if (!e.target.matches('.menu-sold-out-button')) return;
+
+  const $menuName = e.target.previousElementSibling;
+  $menuName.classList.toggle('sold-out');
+
+  const selectedMenuList = JSON.parse(localStorage.getItem('menu'))[
+    selectedMenu
+  ];
+  selectedMenuList[numOfLi]['soldOut'] = !selectedMenuList[numOfLi]['soldOut'];
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
 });
 
 // 수정 버튼 클릭 시, 메뉴 이름 수정

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -77,20 +77,9 @@ const addNewMenu = () => {
   updateTotalMenuNum();
 };
 
-// 메뉴 품절 여부 토글
-const toggleSoldOut = ($li, idx, selectedMenuList) => {
-  const $menuName = $li.firstElementChild;
-  $menuName.classList.toggle('sold-out');
-
-  // localStorage
-  selectedMenuList[idx]['soldOut'] = !selectedMenuList[idx]['soldOut'];
-  menuObj[selectedMenu] = selectedMenuList;
-  localStorage.setItem('menu', JSON.stringify(menuObj));
-};
-
 // 메뉴 수정
-const editMenu = ($li, idx, selectedMenuList) => {
-  const $menuName = $li.firstElementChild;
+const editMenu = target => {
+  const $menuName = target.previousElementSibling;
   const editedName = window.prompt(
     '메뉴명을 수정하세요',
     $menuName.textContent,
@@ -99,25 +88,16 @@ const editMenu = ($li, idx, selectedMenuList) => {
   if (editedName === null) return;
 
   $menuName.textContent = editedName;
-
-  // localStorage
-  selectedMenuList[idx]['name'] = editedName;
-  menuObj[selectedMenu] = selectedMenuList;
-  localStorage.setItem('menu', JSON.stringify(menuObj));
 };
 
 // 메뉴 삭제
-const deleteMenu = ($li, idx, selectedMenuList) => {
-  const $selectedMenu = $li;
+const deleteMenu = target => {
+  const $selectedMenu = target.parentNode;
   const result = window.confirm('정말 삭제하시겠습니까?');
 
   if (!result) return;
 
   $espressoMenuList.removeChild($selectedMenu);
-
-  // localStorage
-  menuObj[selectedMenu] = selectedMenuList.filter((_, index) => index !== idx);
-  localStorage.setItem('menu', JSON.stringify(menuObj));
 };
 
 // event
@@ -140,28 +120,35 @@ $espressoMenuForm.addEventListener('keyup', e => {
   addNewMenu();
 });
 
-// 메뉴별 품절, 수정, 삭제 버튼 클릭 이벤트
+// 품절 버튼 클릭 시, 메뉴 품절 상태 토글
 $espressoMenuList.addEventListener('click', e => {
   const $li = e.target.closest('li');
-  const idxOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
+  const numOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
+
+  if (!e.target.matches('.menu-sold-out-button')) return;
+
+  const $menuName = e.target.previousElementSibling;
+  $menuName.classList.toggle('sold-out');
+
   const selectedMenuList = JSON.parse(localStorage.getItem('menu'))[
     selectedMenu
   ];
+  selectedMenuList[numOfLi]['soldOut'] = !selectedMenuList[numOfLi]['soldOut'];
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
+});
 
-  // 품절 버튼 클릭 시, 메뉴 품절 상태 토글
-  if (e.target.matches('.menu-sold-out-button')) {
-    toggleSoldOut($li, idxOfLi, selectedMenuList);
-    return;
-  }
-  // 수정 버튼 클릭 시, 메뉴 이름 수정
-  if (e.target.matches('.menu-edit-button')) {
-    editMenu($li, idxOfLi, selectedMenuList);
-    return;
-  }
-  // 삭제 버튼 클릭 시, 메뉴 삭제
-  if (e.target.matches('.menu-remove-button')) {
-    deleteMenu($li, idxOfLi, selectedMenuList);
-    updateTotalMenuNum();
-    return;
-  }
+// 수정 버튼 클릭 시, 메뉴 이름 수정
+$espressoMenuList.addEventListener('click', e => {
+  if (!e.target.matches('.menu-edit-button')) return;
+
+  editMenu(e.target);
+});
+
+// 삭제 버튼 클릭 시, 메뉴 삭제
+$espressoMenuList.addEventListener('click', e => {
+  if (!e.target.matches('.menu-remove-button')) return;
+
+  deleteMenu(e.target);
+  updateTotalMenuNum();
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,0 +1,46 @@
+// elem
+const $espressoMenuForm = document.getElementById('espresso-menu-form');
+const $input = document.getElementById('espresso-menu-name');
+
+// 메뉴 추가
+const addNewMenu = menuName => {
+  const $espressoMenuList = document.getElementById('espresso-menu-list');
+
+  const $li = document.createElement('li');
+  $li.classList.add('menu-list-item', 'd-flex', 'items-center', 'py-2');
+  $li.innerHTML = `
+    <span class="w-100 pl-2 menu-name">${menuName}</span>
+    <button
+      type="button"
+      class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
+    >
+      수정
+    </button>
+    <button
+      type="button"
+      class="bg-gray-50 text-gray-500 text-sm menu-remove-button"
+    >
+      삭제
+    </button>
+  `;
+
+  $espressoMenuList.appendChild($li);
+};
+
+// event
+// form의 submit default 이벤트 막기
+$espressoMenuForm.addEventListener('submit', e => {
+  e.preventDefault();
+});
+
+// 확인 버튼 클릭 시, 메뉴 추가
+$espressoMenuForm.addEventListener('click', e => {
+  if (e.target.id !== 'espresso-menu-submit-button') return;
+  if ($input.value.trim() === '') {
+    $input.value = '';
+    return;
+  }
+  const menuName = $input.value;
+  addNewMenu(menuName);
+  $input.value = '';
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -44,3 +44,17 @@ $espressoMenuForm.addEventListener('click', e => {
   addNewMenu(menuName);
   $input.value = '';
 });
+
+// Enter 키 입력 시, 메뉴 추가
+$input.addEventListener('keypress', e => {
+  if (e.key === 'Enter') {
+    if ($input.value.trim() === '') {
+      $input.value = '';
+      return;
+    }
+
+    const menuName = $input.value;
+    addNewMenu(menuName);
+    $input.value = '';
+  }
+});

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -61,7 +61,7 @@ $espressoMenuForm.addEventListener('click', e => {
 });
 
 // Enter 키 입력 시, 메뉴 추가
-$input.addEventListener('keypress', e => {
+$input.addEventListener('keyup', e => {
   if (e.key === 'Enter') {
     addNewMenu();
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -2,6 +2,14 @@
 const $espressoMenuForm = document.getElementById('espresso-menu-form');
 const $espressoMenuList = document.getElementById('espresso-menu-list');
 
+// 총 메뉴갯수 count
+const updateTotalMenuNum = () => {
+  const $menuCount = document.querySelector('.menu-count');
+
+  const totalMenuNum = $espressoMenuList.children.length;
+  $menuCount.textContent = `총 ${totalMenuNum}개`;
+};
+
 // 메뉴 li 만들기
 const makeMenuTemplate = menuName => {
   const $li = document.createElement('li');
@@ -39,14 +47,6 @@ const addNewMenu = () => {
   makeMenuTemplate(menuName);
   $input.value = '';
   updateTotalMenuNum();
-};
-
-// 총 메뉴갯수 count
-const updateTotalMenuNum = () => {
-  const $menuCount = document.querySelector('.menu-count');
-
-  const totalMenuNum = $espressoMenuList.children.length;
-  $menuCount.textContent = `총 ${totalMenuNum}개`;
 };
 
 // 메뉴 수정

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,8 +27,7 @@ const addNewMenu = menuName => {
 };
 
 // 총 메뉴갯수 count
-const getTotalMenuNum = () => {
-  // const $espressoMenuList = document.getElementById('espresso-menu-list');
+const updateTotalMenuNum = () => {
   const $menuCount = document.querySelector('.menu-count');
 
   const totalMenuNum = $espressoMenuList.children.length;
@@ -51,7 +50,7 @@ $espressoMenuForm.addEventListener('click', e => {
   const menuName = $input.value;
   addNewMenu(menuName);
   $input.value = '';
-  getTotalMenuNum();
+  updateTotalMenuNum();
 });
 
 // Enter 키 입력 시, 메뉴 추가
@@ -65,7 +64,7 @@ $input.addEventListener('keypress', e => {
     const menuName = $input.value;
     addNewMenu(menuName);
     $input.value = '';
-    getTotalMenuNum();
+    updateTotalMenuNum();
   }
 });
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -48,6 +48,29 @@ const updateTotalMenuNum = () => {
   $menuCount.textContent = `총 ${totalMenuNum}개`;
 };
 
+// 메뉴 수정
+const editMenu = target => {
+  const $menuName = target.previousElementSibling;
+  const editedName = window.prompt(
+    '메뉴명을 수정하세요',
+    $menuName.textContent,
+  );
+
+  if (editedName === null) return;
+
+  $menuName.textContent = editedName;
+};
+
+// 메뉴 삭제
+const deleteMenu = target => {
+  const $selectedMenu = target.parentNode;
+  const result = window.confirm('정말 삭제하시겠습니까?');
+
+  if (!result) return;
+
+  $espressoMenuList.removeChild($selectedMenu);
+};
+
 // event
 // form의 submit default 이벤트 막기
 $espressoMenuForm.addEventListener('submit', e => {
@@ -71,26 +94,13 @@ $input.addEventListener('keyup', e => {
 $espressoMenuList.addEventListener('click', e => {
   if (!e.target.matches('.menu-edit-button')) return;
 
-  const $menuName = e.target.previousElementSibling;
-  const editedName = window.prompt(
-    '메뉴명을 수정하세요',
-    $menuName.textContent,
-  );
-
-  if (editedName === null) return;
-
-  $menuName.textContent = editedName;
+  editMenu(e.target);
 });
 
 // 삭제 버튼 클릭 시, 메뉴 삭제
 $espressoMenuList.addEventListener('click', e => {
   if (!e.target.matches('.menu-remove-button')) return;
 
-  const $selectedMenu = e.target.parentNode;
-  const result = window.confirm('정말 삭제하시겠습니까?');
-
-  if (!result) return;
-
-  $espressoMenuList.removeChild($selectedMenu);
+  deleteMenu(e.target);
   updateTotalMenuNum();
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,6 +27,15 @@ const addNewMenu = menuName => {
   $espressoMenuList.appendChild($li);
 };
 
+// 총 메뉴갯수 count
+const getTotalMenuNum = () => {
+  const $espressoMenuList = document.getElementById('espresso-menu-list');
+  const $menuCount = document.querySelector('.menu-count');
+
+  const totalMenuNum = $espressoMenuList.children.length;
+  $menuCount.textContent = `총 ${totalMenuNum}개`;
+};
+
 // event
 // form의 submit default 이벤트 막기
 $espressoMenuForm.addEventListener('submit', e => {
@@ -43,6 +52,7 @@ $espressoMenuForm.addEventListener('click', e => {
   const menuName = $input.value;
   addNewMenu(menuName);
   $input.value = '';
+  getTotalMenuNum();
 });
 
 // Enter 키 입력 시, 메뉴 추가
@@ -56,5 +66,6 @@ $input.addEventListener('keypress', e => {
     const menuName = $input.value;
     addNewMenu(menuName);
     $input.value = '';
+    getTotalMenuNum();
   }
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,7 +1,6 @@
 // elem
 const $espressoMenuForm = document.getElementById('espresso-menu-form');
 const $espressoMenuList = document.getElementById('espresso-menu-list');
-const $input = document.getElementById('espresso-menu-name');
 
 // 메뉴 li 만들기
 const makeMenuTemplate = menuName => {
@@ -29,12 +28,14 @@ const makeMenuTemplate = menuName => {
 
 // 메뉴 추가
 const addNewMenu = () => {
+  const $input = document.getElementById('espresso-menu-name');
+  const menuName = $input.value;
+
   if ($input.value.trim() === '') {
     $input.value = '';
     return;
   }
 
-  const menuName = $input.value;
   makeMenuTemplate(menuName);
   $input.value = '';
   updateTotalMenuNum();
@@ -84,7 +85,7 @@ $espressoMenuForm.addEventListener('click', e => {
 });
 
 // Enter 키 입력 시, 메뉴 추가
-$input.addEventListener('keyup', e => {
+$espressoMenuForm.addEventListener('keyup', e => {
   if (e.key === 'Enter') {
     addNewMenu();
   }

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -94,4 +94,5 @@ $espressoMenuList.addEventListener('click', e => {
   if (!result) return;
 
   $espressoMenuList.removeChild($selectedMenu);
+  updateTotalMenuNum();
 });

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -77,9 +77,20 @@ const addNewMenu = () => {
   updateTotalMenuNum();
 };
 
+// 메뉴 품절 여부 토글
+const toggleSoldOut = ($li, idx, selectedMenuList) => {
+  const $menuName = $li.firstElementChild;
+  $menuName.classList.toggle('sold-out');
+
+  // localStorage
+  selectedMenuList[idx]['soldOut'] = !selectedMenuList[idx]['soldOut'];
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
+};
+
 // 메뉴 수정
-const editMenu = target => {
-  const $menuName = target.previousElementSibling;
+const editMenu = ($li, idx, selectedMenuList) => {
+  const $menuName = $li.firstElementChild;
   const editedName = window.prompt(
     '메뉴명을 수정하세요',
     $menuName.textContent,
@@ -88,16 +99,25 @@ const editMenu = target => {
   if (editedName === null) return;
 
   $menuName.textContent = editedName;
+
+  // localStorage
+  selectedMenuList[idx]['name'] = editedName;
+  menuObj[selectedMenu] = selectedMenuList;
+  localStorage.setItem('menu', JSON.stringify(menuObj));
 };
 
 // 메뉴 삭제
-const deleteMenu = target => {
-  const $selectedMenu = target.parentNode;
+const deleteMenu = ($li, idx, selectedMenuList) => {
+  const $selectedMenu = $li;
   const result = window.confirm('정말 삭제하시겠습니까?');
 
   if (!result) return;
 
   $espressoMenuList.removeChild($selectedMenu);
+
+  // localStorage
+  menuObj[selectedMenu] = selectedMenuList.filter((_, index) => index !== idx);
+  localStorage.setItem('menu', JSON.stringify(menuObj));
 };
 
 // event
@@ -120,37 +140,30 @@ $espressoMenuForm.addEventListener('keyup', e => {
   addNewMenu();
 });
 
-// 품절 버튼 클릭 시, 메뉴 품절 상태 토글
+// 메뉴별 품절, 수정, 삭제 버튼 클릭 이벤트
 $espressoMenuList.addEventListener('click', e => {
   const $li = e.target.closest('li');
-  const numOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
-
-  if (!e.target.matches('.menu-sold-out-button')) return;
-
-  const $menuName = e.target.previousElementSibling;
-  $menuName.classList.toggle('sold-out');
-
+  const idxOfLi = [...$espressoMenuList.children].findIndex(li => li === $li);
   const selectedMenuList = JSON.parse(localStorage.getItem('menu'))[
     selectedMenu
   ];
-  selectedMenuList[numOfLi]['soldOut'] = !selectedMenuList[numOfLi]['soldOut'];
-  menuObj[selectedMenu] = selectedMenuList;
-  localStorage.setItem('menu', JSON.stringify(menuObj));
-});
 
-// 수정 버튼 클릭 시, 메뉴 이름 수정
-$espressoMenuList.addEventListener('click', e => {
-  if (!e.target.matches('.menu-edit-button')) return;
-
-  editMenu(e.target);
-});
-
-// 삭제 버튼 클릭 시, 메뉴 삭제
-$espressoMenuList.addEventListener('click', e => {
-  if (!e.target.matches('.menu-remove-button')) return;
-
-  deleteMenu(e.target);
-  updateTotalMenuNum();
+  // 품절 버튼 클릭 시, 메뉴 품절 상태 토글
+  if (e.target.matches('.menu-sold-out-button')) {
+    toggleSoldOut($li, idxOfLi, selectedMenuList);
+    return;
+  }
+  // 수정 버튼 클릭 시, 메뉴 이름 수정
+  if (e.target.matches('.menu-edit-button')) {
+    editMenu($li, idxOfLi, selectedMenuList);
+    return;
+  }
+  // 삭제 버튼 클릭 시, 메뉴 삭제
+  if (e.target.matches('.menu-remove-button')) {
+    deleteMenu($li, idxOfLi, selectedMenuList);
+    updateTotalMenuNum();
+    return;
+  }
 });
 
 // Enter 키 입력 시, 메뉴 추가

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -81,12 +81,14 @@ $espressoMenuForm.addEventListener('submit', e => {
 // 확인 버튼 클릭 시, 메뉴 추가
 $espressoMenuForm.addEventListener('click', e => {
   if (e.target.id !== 'espresso-menu-submit-button') return;
+
   addNewMenu();
 });
 
 // Enter 키 입력 시, 메뉴 추가
 $espressoMenuForm.addEventListener('keyup', e => {
   if (e.key !== 'Enter') return;
+
   addNewMenu();
 });
 

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -86,9 +86,8 @@ $espressoMenuForm.addEventListener('click', e => {
 
 // Enter 키 입력 시, 메뉴 추가
 $espressoMenuForm.addEventListener('keyup', e => {
-  if (e.key === 'Enter') {
-    addNewMenu();
-  }
+  if (e.key !== 'Enter') return;
+  addNewMenu();
 });
 
 // 수정 버튼 클릭 시, 메뉴 이름 수정


### PR DESCRIPTION
## 🎯 step2 요구사항 - 상태 관리로 메뉴 관리하기

- [x] [localStorage](https://developer.mozilla.org/ko/docs/Web/API/Window/localStorage)에 데이터를 저장하여 새로고침해도 데이터가 남아있게 한다.
- [x] 에스프레소, 프라푸치노, 블렌디드, 티바나, 디저트 각각의 종류별로 메뉴판을 관리할 수 있게 만든다.
  - [x] 페이지에 최초로 접근할 때는 에스프레소 메뉴가 먼저 보이게 한다.
- [x] 품절 상태인 경우를 보여줄 수 있게, 품절 버튼을 추가하고 `sold-out` class를 추가하여 상태를 변경한다.

---
스텝2 기존 commit은 4개인데 merge conflict를 해결하다 commit log가 조금 지저분해진 점 양해부탁드립니다

- refactor: 중복되는 localStorage 업데이트 기능 함수로 변환 
- feat: 종류별 메뉴판 관리 기능 추가 및 localStorage와 연동 
- feat: 수정, 삭제 기능 localStorage와 연동 및 이벤트 위임으로 합치기 
- feat: 품절 버튼 클릭 시, 품절 여부 토글 및 localStorage에 반영

