### PR TITLE
[14기 이승효] Step2 상태 관리로 메뉴 관리하기

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,43 +16,12 @@
         <a href="/" class="text-black">
           <h1 class="text-center font-bold">🌝 문벅스 메뉴 관리</h1>
         </a>
-        <nav class="d-flex justify-center flex-wrap">
-          <button
-                  data-category-name="espresso"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            ☕ 에스프레소
-          </button>
-          <button
-                  data-category-name="frappuccino"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🥤 프라푸치노
-          </button>
-          <button
-                  data-category-name="blended"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🍹 블렌디드
-          </button>
-          <button
-                  data-category-name="teavana"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🫖 티바나
-          </button>
-          <button
-                  data-category-name="desert"
-                  class="cafe-category-name btn bg-white shadow mx-1"
-          >
-            🍰 디저트
-          </button>
-        </nav>
+        <nav class="d-flex justify-center flex-wrap" id="menu-category"></nav>
       </header>
       <main class="mt-10 d-flex justify-center">
         <div class="wrapper bg-white p-10">
           <div class="heading d-flex justify-between">
-            <h2 class="mt-1">☕ 에스프레소 메뉴 관리</h2>
+            <h2 class="mt-1" id="category-name">☕ 에스프레소 메뉴 관리</h2>
             <span class="mr-2 mt-4 menu-count">총 0개</span>
           </div>
           <form id="espresso-menu-form">

--- a/src/js/Router.js
+++ b/src/js/Router.js
@@ -1,0 +1,36 @@
+export class Router {
+  constructor() {
+    window.addEventListener('hashchange', this.route.bind(this));
+
+    this.routeTable = [];
+    this.defaultRoute = null;
+  }
+
+  setDefaultPage(page) {
+    this.defaultRoute = { path: '', page };
+  }
+
+  addRoutePath(path, page) {
+    this.routeTable.push({
+      path,
+      page,
+    });
+  }
+
+  route() {
+    const routePath = location.hash;
+
+    if (routePath === '' && this.defaultRoute) {
+      this.defaultRoute.page.render();
+      return;
+    }
+
+    for (const routeInfo of this.routeTable) {
+      if (routePath.includes(routeInfo.path)) {
+        routeInfo.page.clearEvents();
+        routeInfo.page.render();
+        break;
+      }
+    }
+  }
+}

--- a/src/js/components/Component.js
+++ b/src/js/components/Component.js
@@ -1,11 +1,14 @@
+import { setLocalStorageItem } from '../utils/index.js';
+
 export default class Component {
-  constructor(containerId, template) {
+  constructor(containerId, template, stateId) {
     const $container = document.getElementById(containerId);
 
     if (!$container) {
       throw "container doesn't exists";
     }
 
+    if (stateId) this.stateId = stateId;
     this.state = {};
     this.container = $container;
     this.baseTemplate = template;
@@ -17,13 +20,16 @@ export default class Component {
 
   setState(key, value) {
     this.state = { ...this.state, [key]: value };
+    if (this.stateId) {
+      setLocalStorageItem(this.stateId, this.state);
+    }
     this.render();
   }
 
   getHTMLElement(template) {
-    const $wrapper = document.createElement('template');
+    const $wrapper = document.createElement('div');
     $wrapper.innerHTML = template;
-    const $targetElement = $wrapper.content.cloneNode(true);
+    const $targetElement = $wrapper.firstChild.cloneNode(true);
     $wrapper.remove();
     return $targetElement;
   }
@@ -53,6 +59,8 @@ export default class Component {
   makeHTML() {}
 
   init() {}
+
+  clearEvents() {}
 
   render() {}
 }

--- a/src/js/components/Component.js
+++ b/src/js/components/Component.js
@@ -15,13 +15,26 @@ export default class Component {
     this.renderTemplate = template;
     this.htmlList = [];
     this.init();
-    this.render();
+    if (!stateId) this.render();
   }
 
   setState(key, value) {
-    this.state = { ...this.state, [key]: value };
+    if (typeof key === 'string') {
+      this.state = { ...this.state, [key]: value };
+    } else if (typeof key === 'object' && !Array.isArray(key) && key !== null) {
+      this.state = key;
+    } else {
+      throw ': unexpected argument';
+    }
+
     if (this.stateId) {
       setLocalStorageItem(this.stateId, this.state);
+
+      if (this.stateId === location.hash.substring(1)) {
+        this.render();
+      }
+
+      return;
     }
     this.render();
   }

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -1,11 +1,21 @@
 import Component from './Component.js';
 import { ALERT_TEXT } from '../constant/index.js';
-import { makeConfirmAlert, makePrompt } from '../utils/index.js';
+import {
+  getLocalStorageItem,
+  makeConfirmAlert,
+  makePrompt,
+} from '../utils/index.js';
 
 export default class Menu extends Component {
-  constructor(containerId) {
+  constructor(containerId, stateId) {
     const menuListTemplate = `<li class="menu-list-item d-flex items-center py-2">
-      <span class="w-100 pl-2 menu-name">{{name}}</span>
+      <span class="w-100 pl-2 menu-name {{isSoldOut}}">{{name}}</span>
+      <button
+      type="button"
+      class="bg-gray-50 text-gray-500 text-sm mr-1 menu-sold-out-button"
+    >
+      품절
+    </button>
       <button
           type="button"
           class="bg-gray-50 text-gray-500 text-sm mr-1 menu-edit-button"
@@ -19,34 +29,33 @@ export default class Menu extends Component {
       삭제
       </button>
       </li>`;
-    super(containerId, menuListTemplate);
+    super(containerId, menuListTemplate, stateId);
+    this.stateId = stateId;
   }
 
   init() {
-    this.setState('menu', []);
-    this.setState('count', 0);
-    const $menuSubmitForm = document.getElementById('espresso-menu-form');
+    const storedState = getLocalStorageItem(this.stateId);
+    if (storedState) {
+      this.setState('menu', storedState.menu || []);
+      this.setState('soldOut', storedState.soldOut || []);
+      this.setState('count', storedState.count || 0);
+    } else {
+      this.setState('menu', []);
+      this.setState('soldOut', []);
+      this.setState('count', 0);
+    }
+  }
 
-    $menuSubmitForm.addEventListener('submit', (e) => {
+  clearEvents() {
+    const $menuSubmitForm = document.getElementById('espresso-menu-form');
+    const clone = $menuSubmitForm.cloneNode(true);
+
+    clone.addEventListener('submit', (e) => {
       e.preventDefault();
       this.addMenu();
     });
 
-    this.container.addEventListener('click', ({ target }) => {
-      if (!target) return;
-
-      if (target.classList.contains('menu-remove-button')) {
-        const menuItem =
-          target.parentNode.querySelector('.menu-name').innerText;
-        return this.deleteMenu(menuItem);
-      }
-
-      if (target.classList.contains('menu-edit-button')) {
-        const menuItem =
-          target.parentNode.querySelector('.menu-name').innerText;
-        return this.updateMenu(menuItem);
-      }
-    });
+    $menuSubmitForm.parentNode.replaceChild(clone, $menuSubmitForm);
   }
 
   checkDuplication(newMenu) {
@@ -77,12 +86,24 @@ export default class Menu extends Component {
     this.setState('menu', [...this.state.menu, { name: newMenu }]);
   }
 
+  setSoldOutMenu(target) {
+    if (this.state.soldOut.includes(target)) {
+      this.setState(
+        'soldOut',
+        this.state.soldOut.filter((menu) => menu !== target)
+      );
+    } else {
+      this.setState('soldOut', [...this.state.soldOut, target]);
+    }
+  }
+
   updateMenu(target) {
     const newName = makePrompt(ALERT_TEXT.MENU_UPDATE);
     if (this.checkDuplication(newName)) {
       alert(ALERT_TEXT.MENU_EXIST);
       return;
     }
+
     const targetObj = this.state.menu.find((menu) => menu.name === target);
     if (!newName || newName.replaceAll(' ', '') === '' || !targetObj) return;
     targetObj.name = newName;
@@ -96,13 +117,39 @@ export default class Menu extends Component {
       'menu',
       this.state.menu.filter((menu) => menu.name !== target)
     );
+    this.setState(
+      'soldOut',
+      this.state.soldOut.filter((menu) => menu !== target)
+    );
   }
 
   makeHTML() {
     this.state.menu.forEach((menu) => {
       this.updateTemplate('name', menu.name);
 
+      if (this.state.soldOut && this.state.soldOut.includes(menu.name)) {
+        this.updateTemplate('isSoldOut', 'sold-out');
+      } else {
+        this.updateTemplate('isSoldOut', '');
+      }
+
       const $templateElement = this.getHTMLElement(this.renderTemplate);
+
+      $templateElement.addEventListener('click', ({ target }) => {
+        if (!target) return;
+
+        if (target.classList.contains('menu-remove-button')) {
+          return this.deleteMenu(menu.name);
+        }
+
+        if (target.classList.contains('menu-edit-button')) {
+          return this.updateMenu(menu.name);
+        }
+
+        if (target.classList.contains('menu-sold-out-button')) {
+          this.setSoldOutMenu(menu.name);
+        }
+      });
 
       this.htmlList.push($templateElement);
       this.resetRenderTemplate();

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -35,15 +35,17 @@ export default class Menu extends Component {
 
   init() {
     const storedState = getLocalStorageItem(this.stateId);
+
     if (storedState) {
-      this.setState('menu', storedState.menu || []);
-      this.setState('soldOut', storedState.soldOut || []);
-      this.setState('count', storedState.count || 0);
-    } else {
-      this.setState('menu', []);
-      this.setState('soldOut', []);
-      this.setState('count', 0);
+      this.setState(storedState);
+      return;
     }
+
+    this.setState({
+      menu: [],
+      soldOut: [],
+      count: 0,
+    });
   }
 
   clearEvents() {

--- a/src/js/components/Menu.js
+++ b/src/js/components/Menu.js
@@ -110,6 +110,7 @@ export default class Menu extends Component {
     if (!newName || newName.replaceAll(' ', '') === '' || !targetObj) return;
     targetObj.name = newName;
     this.setState('menu', [...this.state.menu]);
+    this.setSoldOutMenu(target);
   }
 
   deleteMenu(target) {

--- a/src/js/components/MenuCategory.js
+++ b/src/js/components/MenuCategory.js
@@ -19,8 +19,7 @@ export default class MenuCategory extends Component {
       if (!target) return;
 
       if (target.classList.contains('cafe-category-name')) {
-        const categoryId = target.id;
-        const categoryName = target.textContent;
+        const { id: categoryId, textContent: categoryName } = target;
 
         this.changeHash(categoryId);
         this.updateCategoryName(categoryName);

--- a/src/js/components/MenuCategory.js
+++ b/src/js/components/MenuCategory.js
@@ -1,0 +1,56 @@
+import { CATEGORY_LIST } from '../constant/index.js';
+import Component from './Component.js';
+
+export default class MenuCategory extends Component {
+  constructor(containerId) {
+    const menuGroupTemplate = `<button
+    id="{{id}}"
+    class="cafe-category-name btn bg-white shadow mx-1"
+  >
+    {{name}}
+  </button>`;
+    super(containerId, menuGroupTemplate);
+  }
+
+  init() {
+    window.location.hash = 'espresso';
+
+    this.container.addEventListener('click', ({ target }) => {
+      if (!target) return;
+
+      if (target.classList.contains('cafe-category-name')) {
+        const categoryId = target.id;
+        const categoryName = target.textContent;
+
+        this.changeHash(categoryId);
+        this.updateCategoryName(categoryName);
+      }
+    });
+  }
+
+  changeHash(hash) {
+    window.location.hash = hash;
+  }
+
+  updateCategoryName(categoryName) {
+    const $categoryName = document.getElementById('category-name');
+    $categoryName.textContent = `${categoryName} 메뉴 관리`;
+  }
+
+  makeHTML() {
+    CATEGORY_LIST.forEach((category) => {
+      this.updateTemplate('id', category.id);
+      this.updateTemplate('name', category.name);
+
+      const $templateElement = this.getHTMLElement(this.renderTemplate);
+
+      this.htmlList.push($templateElement);
+      this.resetRenderTemplate();
+    });
+  }
+
+  render() {
+    this.makeHTML();
+    this.updateView();
+  }
+}

--- a/src/js/constant/index.js
+++ b/src/js/constant/index.js
@@ -3,3 +3,11 @@ export const ALERT_TEXT = Object.freeze({
   MENU_DELETE: '해당 메뉴를 삭제하시겠습니까?',
   MENU_UPDATE: '수정할 메뉴명을 입력하세요.',
 });
+
+export const CATEGORY_LIST = [
+  { id: 'espresso', name: '☕ 에스프레소' },
+  { id: 'frappuccino', name: '🥤 프라푸치노' },
+  { id: 'blended', name: '🍹 블렌디드' },
+  { id: 'teavana', name: '🫖 티바나' },
+  { id: 'dessert', name: '🍰 디저트' },
+];

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,3 +1,5 @@
 import Menu from './components/Menu.js';
+import MenuCategory from './components/MenuCategory.js';
 
 const menu = new Menu('espresso-menu-list');
+const menuCategory = new MenuCategory('menu-category');

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,19 @@
 import Menu from './components/Menu.js';
 import MenuCategory from './components/MenuCategory.js';
+import { CATEGORY_LIST } from './constant/index.js';
+import { Router } from './Router.js';
 
-const menu = new Menu('espresso-menu-list');
 const menuCategory = new MenuCategory('menu-category');
+
+const router = new Router();
+
+CATEGORY_LIST.forEach((category) => {
+  const menu = new Menu('espresso-menu-list', category.id);
+  router.addRoutePath(category.id, menu);
+
+  if (category.id === 'espresso') {
+    router.setDefaultPage(menu);
+  }
+});
+
+router.route();

--- a/src/js/utils/index.js
+++ b/src/js/utils/index.js
@@ -5,3 +5,20 @@ export function makeConfirmAlert(msg) {
 export function makePrompt(msg) {
   return prompt(msg);
 }
+
+export function getLocalStorageItem(stateId) {
+  try {
+    const state = localStorage.getItem(`moonbucks/${stateId}`);
+    return JSON.parse(state);
+  } catch (e) {
+    console.error(e);
+  }
+}
+
+export function setLocalStorageItem(stateId, state) {
+  try {
+    localStorage.setItem(`moonbucks/${stateId}`, JSON.stringify(state));
+  } catch (e) {
+    console.error(e);
+  }
+}


### PR DESCRIPTION
## 🎯 step2 요구사항 - 상태 관리로 메뉴 관리하기

- [X] [localStorage](https://developer.mozilla.org/ko/docs/Web/API/Window/localStorage)에 데이터를 저장하여 새로고침해도 데이터가 남아있게 한다.
- [X] 에스프레소, 프라푸치노, 블렌디드, 티바나, 디저트 각각의 종류별로 메뉴판을 관리할 수 있게 만든다.
  - [X] 페이지에 최초로 접근할 때는 에스프레소 메뉴가 먼저 보이게 한다.
- [X] 품절 상태인 경우를 보여줄 수 있게, 품절 버튼을 추가하고 `sold-out` class를 추가하여 상태를 변경한다.

---------------------------------
아쉬운 점 : 
1. 이미 등록된 이벤트 초기화 하는 부분을 좀 더 효과적으로 할 수 없을까?
2. 통합 store를 만들어서 state를 관리하는 방법으로 바꾸는 것이 더 좋을까?